### PR TITLE
Distinguish skipped instructions from invalid instructions

### DIFF
--- a/api/src/main/java/io/github/applecommander/disassembler/api/Disassembler.java
+++ b/api/src/main/java/io/github/applecommander/disassembler/api/Disassembler.java
@@ -43,7 +43,7 @@ public class Disassembler {
         while (program.hasMore()) {
             Instruction instruction = null;
             if (program.currentOffset() < bytesToSkip) {
-                instruction = InvalidInstruction.from(program);
+                instruction = SkippedInstruction.from(program);
             }
             else {
                 instruction = instructionSet.decode(program);

--- a/api/src/main/java/io/github/applecommander/disassembler/api/SkippedInstruction.java
+++ b/api/src/main/java/io/github/applecommander/disassembler/api/SkippedInstruction.java
@@ -2,18 +2,18 @@ package io.github.applecommander.disassembler.api;
 
 import java.util.Optional;
 
-public class InvalidInstruction implements Instruction {
+public class SkippedInstruction implements Instruction {
     public static Instruction from(Program program) {
         int currentAddress = program.currentAddress();  // Need capture before read
         byte[] code = program.read(1);
-        return new InvalidInstruction(currentAddress, code);
+        return new SkippedInstruction(currentAddress, code);
     }
     
     private int address;
     private byte[] code;
     private String addressLabel;
     
-    InvalidInstruction(int address, byte[] code) {
+    SkippedInstruction(int address, byte[] code) {
         this.address = address;
         this.code = code;
     }
@@ -45,7 +45,7 @@ public class InvalidInstruction implements Instruction {
     
     @Override
     public String getOpcodeMnemonic() {
-        return "???";
+        return "---";
     }
 
     @Override


### PR DESCRIPTION
The disassembler display both skipped instructions and invalid instructions as `???`. 

For example, `acdasm c600 –a=0xc600 –-offset=4`

```
C600- A2                   ???
C601- 20                   ???
C602- A0                   ???
C603- 00                   ???
C604- A2 03                LDX #$03
C606- 86 3C     LC606      STX $3C
C608- 8A                   TXA
C609- 0A                   ASL
```

Apple II Programmers are used to interpreting `???` as invalid opcodes. In this listing, The first opcode `A2` is not invalid. It is the opcode of `LDX #` instruction. 

I have renamed the class ```InvalidInstruction``` to ```SkippedInstruction``` and display the mnemonic as `---`. Here is the sample output.

```
C600- A2                   ---
C601- 20                   ---
C602- A0                   ---
C603- 00                   ---
C604- A2 03                LDX #$03
C606- 86 3C     LC606      STX $3C
C608- 8A                   TXA
C609- 0A                   ASL
```
